### PR TITLE
Fix auto_now arguments in create/update of User model

### DIFF
--- a/core/user/models.py
+++ b/core/user/models.py
@@ -62,8 +62,8 @@ class User(AbstractBaseUser, PermissionsMixin):
     bio = models.TextField(null=True)
     avatar = models.ImageField(null=True)
 
-    created = models.DateTimeField(auto_now=True)
-    updated = models.DateTimeField(auto_now_add=True)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['username']


### PR DESCRIPTION
The auto_now and auto_now_add arguments in the User model are swapped. The auto_now_add should be used for the create field, otherwise that will be updated everytime the user is saved. Reference: https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.DateField.auto_now